### PR TITLE
Address #2 - Fix blocking read

### DIFF
--- a/epoll.c
+++ b/epoll.c
@@ -70,7 +70,7 @@ static void set_sockaddr(struct sockaddr_in *addr)
 
 static int setnonblocking(int sockfd)
 {
-	if (fcntl(sockfd, F_SETFD, fcntl(sockfd, F_GETFD, 0) | O_NONBLOCK) ==
+	if (fcntl(sockfd, F_SETFL, fcntl(sockfd, F_GETFL, 0) | O_NONBLOCK) ==
 	    -1) {
 		return -1;
 	}


### PR DESCRIPTION
Implements the fix discussed in https://github.com/onestraw/epoll-example/issues/2. Right now, the code block on the read in line 132:

https://github.com/onestraw/epoll-example/blob/f1f1e6e356daf4414d1113e1c6fa485504d8e587/epoll.c#L132-L133

This is because `fcntl` is passed the `F_SETFD` and `F_GETFD` arguments:

https://github.com/onestraw/epoll-example/blob/f1f1e6e356daf4414d1113e1c6fa485504d8e587/epoll.c#L73

As @BlurryLight mentioned, `F_SETFD` and `F_GETFD` are only for `FD_CLOEXEC`, and the [fcntl man page](https://man7.org/linux/man-pages/man2/fcntl.2.html) says that `O_NONBLOCK` can only be set when `F_SETFL` and `F_GETFL` are used. 

With these proposed changes, I'm able to keep multiple connections open and running without the `read` blocking.

Thank you for this example! It's been very helpful!
